### PR TITLE
Split npath call

### DIFF
--- a/src/info.jl
+++ b/src/info.jl
@@ -10,6 +10,7 @@ abstract type AbstractPaths end
 struct Paths <: AbstractPaths
     paths::Vector{Path}
 end
+npaths(paths::Paths) = length(paths.paths)
 
 ################################################################################
 # Utilities to manipulate TimerOutput object
@@ -49,7 +50,7 @@ mutable struct Result
 end
 
 Result() = Result(Paths(Path[]), :Unbounded, 0.0, Inf, 0.0)
-npaths(result::Result) = length(result.paths.paths)
+npaths(result::Result) = npaths(result.paths)
 
 function Base.show(io::IO, result::Result)
     println(io, "Exact Lower Bound: $(result.lowerbound)")


### PR DESCRIPTION
This is necessary for `npaths` to work with StructDualDynProg as in StructDualDynProg, `length(result.paths.paths)` is the number of stages and not the number of paths.

@gerardcel this is the cause of the bug we had with the number of interations being incorrect. This is because the `npaths` computed was the number of stages and not the number of paths so Pereira was incorrectly computing the variance